### PR TITLE
Bug fix when using conjugate complex filters

### DIFF
--- a/harmonic_network_ops.py
+++ b/harmonic_network_ops.py
@@ -43,7 +43,7 @@ def h_conv(X, W, strides=(1,1,1,1), padding='VALID', max_order=1, name='h_conv')
                 # conjugate weights.
                 if Xsh[4] == 2:
                     Wr += [weights[0],-sign*weights[1]]
-                    Wi += [weights[1],sign*weights[0]]
+                    Wi += [sign*weights[1],weights[0]]
                 else:
                     Wr += [weights[0]]
                     Wi += [weights[1]]


### PR DESCRIPTION
Minor bug fix in filter creation for h_conv.
For conjugate complex filters, the imaginary part needs to be multiplied with the sign of the rotation order. For W_i you multiplied the real part with the sign instead. 